### PR TITLE
feat: Implement JSX element detection & config rule matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use swc_core::ecma::{
     ast::*,
-    visit::{as_folder, FoldWith, VisitMut},
+    visit::{as_folder, FoldWith, VisitMut, VisitMutWith},
 };
 use swc_core::plugin::{plugin_transform, proxies::TransformPluginProgramMetadata};
 
@@ -20,6 +20,36 @@ impl LoggerTransformer {
 }
 
 impl VisitMut for LoggerTransformer {
+    fn visit_mut_jsx_element(&mut self, jsx_element: &mut JSXElement) {
+ 
+        if let JSXElementName::Ident(ident) = &jsx_element.opening.name {
+            println!("Found JSX element: {}", ident.sym);
+            
+            for attr in &jsx_element.opening.attrs {
+                match attr {
+                    JSXAttrOrSpread::JSXAttr(jsx_attr) => {
+                        if let JSXAttrName::Ident(attr_name) = &jsx_attr.name {
+                            println!("Attribute: {}", attr_name.sym);
+                            
+                            if attr_name.sym.starts_with("data-") {
+                                println!("Found data attribute: {}", attr_name.sym);
+                                
+                                let data_key = attr_name.sym.as_str();
+                                if let Some(rule) = self.config.rules.get(data_key) {
+                                    println!("Found matching rule for {}: type={}", data_key, rule.r#type);
+                                }
+                            }
+                        }
+                    }
+                    JSXAttrOrSpread::SpreadElement(_) => {
+                        println!("Spread attribute found");
+                    }
+                }
+            }
+        }
+        
+        jsx_element.visit_mut_children_with(self);
+    }
 }
 
 #[plugin_transform]
@@ -34,9 +64,9 @@ pub fn process_transform(program: Program, _metadata: TransformPluginProgramMeta
     };
     
     match LoggerTransformer::new(&config_path) {
-        Ok(_transformer) => {
+        Ok(transformer) => {
             println!("Config parsing successful from: {}", config_path);
-            program
+            program.fold_with(&mut as_folder(transformer))
         }
         Err(e) => {
             eprintln!("Config parsing error: {}", e);


### PR DESCRIPTION
## Changes

- Implemented JSX element traversal using `VisitMut` trait
- Added `data-*` attribute detection and logging.
- Matched found data attributes with config rules.  Only `data-*` attributes supported for rule matching.